### PR TITLE
fix: dynamic height directive was not initializing correctly

### DIFF
--- a/src/directives/dynamicHeight/dynamicHeight.js
+++ b/src/directives/dynamicHeight/dynamicHeight.js
@@ -1,23 +1,30 @@
-const setOverflowHidden = el => {
+function setOverflowHidden(el) {
   el.style.overflow = 'hidden';
-};
+}
 
-const setMinHeghtWhenRequested = (el, binding) => {
+function setMinHeghtWhenRequested(el, binding) {
   if (binding.value && binding.value.minHeight) {
     el.style['min-height'] = binding.value.minHeight;
   }
-};
+}
 
-const updateElementHeight = options => {
+function updateElementHeight(options) {
   options.target.style.height = 0;
   options.target.style.height = `${options.target.scrollHeight}px`;
-};
+}
+
+function initElementHeight(el) {
+  setTimeout(() => {
+    updateElementHeight({ target: el });
+  });
+}
 
 export default {
   bind: (el, binding) => {
-    if (binding.value && binding.value.disabled) { return; }
+    if (binding.value?.disabled) { return; }
     setOverflowHidden(el);
     setMinHeghtWhenRequested(el, binding);
+    initElementHeight(el);
     el.addEventListener('input', updateElementHeight);
   },
   unbind: (el, binding) => {

--- a/src/directives/dynamicHeight/dynamicHeight.test.js
+++ b/src/directives/dynamicHeight/dynamicHeight.test.js
@@ -1,5 +1,7 @@
 import dynamicHeight from './dynamicHeight';
 
+jest.useFakeTimers();
+
 describe('Dynamic Height Directive', () => {
   it('should set overflow hidden when initialized', () => {
     const binding = {};
@@ -27,6 +29,20 @@ describe('Dynamic Height Directive', () => {
     };
     dynamicHeight.bind(el, binding);
     expect(el.style['min-height']).toBe('30px');
+  });
+
+  it('should initialize element with correct height', () => {
+    const binding = {};
+    const el = {
+      scrollHeight: 50,
+      style: {
+        height: '10px',
+      },
+      addEventListener: jest.fn(),
+    };
+    dynamicHeight.bind(el, binding);
+    jest.runAllTimers();
+    expect(el.style.height).toBe('50px');
   });
 
   it('should add input event listener on element when directive is bounded', () => {
@@ -88,6 +104,7 @@ describe('Dynamic Height Directive', () => {
       },
       addEventListener: (eventType, callback) => {
         callback(options);
+        expect(eventType).toBe('input');
       },
     };
     dynamicHeight.bind(el, binding);


### PR DESCRIPTION
## Why

Dynamic height directive was no working when field had been rendered with a content already.

## what

* Implemented a init fix;
* Refactored tests code.

## Preview

### Wrong behavior 

![With Bug](https://user-images.githubusercontent.com/11657454/76166899-ff76d300-6140-11ea-862a-5a15d582c8c9.gif)

### Correct behavior

![Without Bug](https://user-images.githubusercontent.com/11657454/76166907-0998d180-6141-11ea-9610-9729e0a0754d.gif)
