### PR TITLE
feat: shrink date when start and end date in same day

### DIFF
--- a/src/library/components/timeCountdown/TimeCountdown.vue
+++ b/src/library/components/timeCountdown/TimeCountdown.vue
@@ -12,7 +12,7 @@
         {{ isNegative ? 'overdue time' : 'time left'}}
       </div>
       <div slot="footer">
-        <small>should finish at {{ endTimeFormatted }}</small>
+        <small>should be finished at {{ endTimeFormatted }}</small>
       </div>
     </tw-time-display>
   </div>
@@ -23,6 +23,8 @@ import TwTimeDisplay from '../timeDisplay/TimeDisplay.vue';
 import {
   momentFactory,
   getFullFormatOf,
+  getTimeFormatOf,
+  isSameDay,
 } from '../../services/timeService/timeService';
 
 function getIntervalInMiliseconds(precision) {
@@ -36,6 +38,9 @@ function getIntervalInMiliseconds(precision) {
 export default {
   name: 'TwTimeCountdown',
   props: {
+    timeFrom: {
+      type: [String, Object, Number],
+    },
     timeTarget: {
       type: [String, Object, Number],
       required: true,
@@ -64,7 +69,12 @@ export default {
       return 'primary';
     },
     endTimeFormatted() {
-      return getFullFormatOf(this.timeTarget);
+      return this.shouldShowFullDate
+        ? getTimeFormatOf(this.timeTarget)
+        : getFullFormatOf(this.timeTarget);
+    },
+    shouldShowFullDate() {
+      return !this.timeFrom || isSameDay(this.timeFrom, this.timeTarget);
     },
   },
   watch: {

--- a/src/library/components/timeFormat/TimeFormatMoment.vue
+++ b/src/library/components/timeFormat/TimeFormatMoment.vue
@@ -57,12 +57,12 @@ export default {
       const month = this.shouldShowMonth ? 'MMMM ' : '';
       const weekDay = this.shouldShowDay ? 'ddd, ' : '';
       const day = this.shouldShowDay ? 'Do ' : '';
-      const hour = this.shouldShowHour ? 'h' : '';
+      const hour = this.shouldShowHour ? 'HH' : '';
       const min = this.shouldShowMin ? ':mm' : '';
       const sec = this.shouldShowSec ? ':ss' : '';
-      const ampm = this.shouldShowHour ? ' a' : '';
+      const h = this.shouldShowHour ? '\\h' : '';
 
-      return `${weekDay}${month}${day}${year}${hour}${min}${sec}${ampm}`;
+      return `${weekDay}${month}${day}${year}${hour}${min}${sec}${h}`;
     },
   },
 };

--- a/src/library/services/timeService/timeService.js
+++ b/src/library/services/timeService/timeService.js
@@ -23,7 +23,11 @@ export function getTimestampOf(value) {
 }
 
 export function getFullFormatOf(value) {
-  return momentFactory(value).format('dddd, MMMM Do YYYY, HH:mm a');
+  return momentFactory(value).format('dddd, MMMM Do YYYY, HH:mm\\h');
+}
+
+export function getTimeFormatOf(value) {
+  return momentFactory(value).format('HH:mm\\h');
 }
 
 export function getISOStringOf(value) {
@@ -51,4 +55,12 @@ export function durationFactory(value) {
 
 export function isDuration(value) {
   return Moment.isDuration(value);
+}
+
+export function isSameDay(rawDateOne, rawDateTwo) {
+  const dateOne = momentFactory(rawDateOne);
+  const dateTwo = momentFactory(rawDateTwo);
+  return dateOne.year() === dateTwo.year()
+    && dateOne.month() === dateTwo.month()
+    && dateOne.date() === dateTwo.date();
 }

--- a/src/pages/meetingDashboard/meetingDashboard.vue
+++ b/src/pages/meetingDashboard/meetingDashboard.vue
@@ -10,6 +10,7 @@
                 <tw-box>
                   <tw-time-countdown
                     size="lg"
+                    :time-from="expectedStartTime"
                     :time-target="expectedEndTime"
                     :disabled="!isMeetingActive" />
                 </tw-box>

--- a/src/pages/meetingForm/meetingForm.vue
+++ b/src/pages/meetingForm/meetingForm.vue
@@ -127,11 +127,7 @@ export default {
       return 'cccc, d LLL yyyy, HH:mm';
     },
     isStartAndEndTimeDuringSameDay() {
-      return this.expectedStartTime
-        && this.expectedEndTime
-        && this.expectedStartTime
-          .substring(0, 10) === this.expectedEndTime
-          .substring(0, 10);
+      return this.$twServices.time.isSameDay(this.expectedStartTime, this.expectedEndTime);
     },
   },
   methods: {

--- a/src/pages/meetingReport/TemplatePreviewModal.vue
+++ b/src/pages/meetingReport/TemplatePreviewModal.vue
@@ -11,18 +11,32 @@
       <tr>
         <td>
           <h1 :style="styles.h1">{{ currentMeeting.name }}</h1>
-          <div style="margin-bottom: 5px;">
+          <template v-if="isStartAndEndTimeDuringSameDay">
             <label :style="styles.label">
-              &#9200; Started at <tw-time-format
-                :time="currentMeeting.realStartTime" />
+              &#9200; Happened <tw-time-format
+                :time="currentMeeting.realStartTime"
+                precision="day"
+              /> from {{
+                getTimeFormatted('realStartTime')
+              }} to {{
+                getTimeFormatted('realEndTime')
+              }}.
             </label>
-          </div>
-          <div>
-            <label :style="styles.label">
-              &#9200; Ended at <tw-time-format
-                :time="currentMeeting.realEndTime" />
-            </label>
-          </div>
+          </template>
+          <template v-else>
+            <div style="margin-bottom: 5px;">
+              <label :style="styles.label">
+                &#9200; Started at <tw-time-format
+                  :time="currentMeeting.realStartTime" />
+              </label>
+            </div>
+            <div>
+              <label :style="styles.label">
+                &#9200; Ended at <tw-time-format
+                  :time="currentMeeting.realEndTime" />
+              </label>
+            </div>
+          </template>
           <tw-template-preview-modal-article
             v-if="currentMeeting.description"
             :text="currentMeeting.description" />
@@ -32,6 +46,7 @@
         <td>
           <tw-template-preview-modal-goals
             :styles="styles"
+            :should-show-full-date="!isStartAndEndTimeDuringSameDay"
             :goals="currentMeeting.goals" />
         </td>
       </tr>
@@ -129,6 +144,11 @@ export default {
         anchor: 'cursor: pointer; color: #967f30; text-decoration: none;',
       };
     },
+    isStartAndEndTimeDuringSameDay() {
+      const { expectedStartTime, expectedEndTime } = this.currentMeeting;
+      return this.$twServices
+        .time.isSameDay(expectedStartTime, expectedEndTime);
+    },
   },
   methods: {
     onClose() {
@@ -141,6 +161,10 @@ export default {
     },
     onCopyBlur() {
       this.copied = false;
+    },
+    getTimeFormatted(timeKey) {
+      return this.$twServices
+        .time.getTimeFormatOf(this.currentMeeting[timeKey]);
     },
   },
   components: {

--- a/src/pages/meetingReport/TemplatePreviewModalGoals.vue
+++ b/src/pages/meetingReport/TemplatePreviewModalGoals.vue
@@ -8,10 +8,13 @@
         :key="goal.id">
           <h3 :style="styles.h3">{{ index + 1 }}. {{ goal.name }}</h3>
           <label :style="styles.label">
-            <span v-if="goal.finishedAt">&#9989; Done at </span>
-            <tw-time-format
-              v-if="goal.finishedAt"
-              :time="goal.finishedAt" />
+            <template v-if="goal.finishedAt">
+              <span>&#9989; Done at </span>
+              <tw-time-format
+                v-if="shouldShowFullDate"
+                :time="goal.finishedAt" />
+              <span v-else>{{ getTimeFormatted(goal.finishedAt) }}</span>
+            </template>
             <span v-else>&#9888; Item has not been completed</span>
             <p v-if="shouldShowWeight">
               <small>Weight: {{ goal.weight || 1 }}</small>
@@ -38,6 +41,7 @@ export default {
       required: true,
     },
     styles: Object,
+    shouldShowFullDate: Boolean,
   },
   components: {
     TwTemplatePreviewModalArticle,
@@ -45,6 +49,11 @@ export default {
   computed: {
     shouldShowWeight() {
       return this.goals.some(item => item.weight !== 1);
+    },
+  },
+  methods: {
+    getTimeFormatted(time) {
+      return this.$twServices.time.getTimeFormatOf(time);
     },
   },
 };

--- a/src/pages/meetingReport/meetingReport.vue
+++ b/src/pages/meetingReport/meetingReport.vue
@@ -3,19 +3,31 @@
     <tw-page>
       <tw-header>
         <tw-heading size="xl" :title="name" />
-        <tw-heading size="xxs">
-          &#9200; Started at <tw-time-format :time="realStartTime" />
-        </tw-heading>
-        <tw-heading size="xxs">
-          &#9200; Finished at <tw-time-format :time="realEndTime" />
-        </tw-heading>
+        <template v-if="isStartAndEndTimeDuringSameDay">
+          <tw-heading size="xxs">
+            &#9200; Happened <tw-time-format
+              :time="realStartTime"
+              precision="day"
+            /> from {{ getTimeFormatted(realStartTime) }} to {{ getTimeFormatted(realEndTime) }}.
+          </tw-heading>
+        </template>
+        <template v-else>
+          <tw-heading size="xxs">
+            &#9200; Started at <tw-time-format :time="realStartTime" />
+          </tw-heading>
+          <tw-heading size="xxs">
+            &#9200; Finished at <tw-time-format :time="realEndTime" />
+          </tw-heading>
+        </template>
         <tw-article v-if="description" :text="description" />
       </tw-header>
       <main>
         <tw-row>
           <tw-col>
             <tw-heading size="lg" title="Goals" />
-            <tw-meeting-report-goals :goals="goals" />
+            <tw-meeting-report-goals
+              :goals="goals"
+              :should-show-full-date="!isStartAndEndTimeDuringSameDay" />
           </tw-col>
         </tw-row>
         <tw-row v-if="sideTopics.length">
@@ -113,6 +125,10 @@ export default {
         finishedAt: goal.finishedAt || null,
       }));
     },
+    isStartAndEndTimeDuringSameDay() {
+      return this.$twServices
+        .time.isSameDay(this.expectedStartTime, this.expectedEndTime);
+    },
   },
   methods: {
     validateRequiredData() {
@@ -162,6 +178,9 @@ export default {
           chartImageSrc: this.getChartImageSrc(),
         },
       }).open();
+    },
+    getTimeFormatted(time) {
+      return this.$twServices.time.getTimeFormatOf(time);
     },
   },
   mounted() {

--- a/src/pages/meetingReport/meetingReportGoals.vue
+++ b/src/pages/meetingReport/meetingReportGoals.vue
@@ -7,10 +7,13 @@
       <div class="tw-u-margin--bottom">
         <tw-heading size="md">{{ index + 1 }}. {{ goal.name }}</tw-heading>
         <tw-heading size="xxs">
-          <span v-if="goal.finishedAt">&#9989; Done at </span>
-          <tw-time-format
-            v-if="goal.finishedAt"
-            :time="goal.finishedAt" />
+          <template v-if="goal.finishedAt">
+            <span>&#9989; Done at </span>
+            <tw-time-format
+              v-if="shouldShowFullDate"
+              :time="goal.finishedAt" />
+            <span v-else>{{ getTimeFormatted(goal.finishedAt) }}</span>
+          </template>
           <span v-else>&#9888; Item has not been completed</span>
           <p v-if="shouldShowWeight">
             <small>Weight: {{ goal.weight || 1 }}</small>
@@ -30,10 +33,16 @@ export default {
   name: 'TwMeetingReportGoals',
   props: {
     goals: Array,
+    shouldShowFullDate: Boolean,
   },
   computed: {
     shouldShowWeight() {
       return this.goals.some(item => item.weight !== 1);
+    },
+  },
+  methods: {
+    getTimeFormatted(time) {
+      return this.$twServices.time.getTimeFormatOf(time);
     },
   },
 };


### PR DESCRIPTION
## why

When event has start and end time inside same day, the full date becomes redundant and could be hidden when repeated.

## what

* Checked if start and end date is inside same day in all points that descriptive data were shown.